### PR TITLE
 inline carrier functions to reduce overhead

### DIFF
--- a/ir/tx.c
+++ b/ir/tx.c
@@ -34,14 +34,14 @@ EventGroupHandle_t tx_flags;
 #define TX_FLAG_READY (1 << 0)
 
 
-static void gen_carrier() {
+static inline void gen_carrier() {
     iomux_set_function(gpio_to_iomux(IR_GPIO_NUM), IOMUX_GPIO14_FUNC_I2SI_WS);
 
     I2S.CONF = SET_MASK_BITS(I2S.CONF, I2S_CONF_RX_START);
 }
 
 
-static void clr_carrier() {
+static inline void clr_carrier() {
     gpio_enable(IR_GPIO_NUM, GPIO_OUTPUT);
     gpio_write(IR_GPIO_NUM, 0);
     I2S.CONF = CLEAR_MASK_BITS(I2S.CONF, I2S_CONF_RX_START);


### PR DESCRIPTION
I fork your project and create [esp-ir for ESP8266_RTOS_SDK 3.2](https://github.com/Fonger/ESP8266-RTOS-IR). I find inline functions critical and can help increase the stability in ESP8266_RTOS_SDK version. I think this change may help in esp-open-rtos too.

Although in esp-open-rtos, the default configuration will inline it. Just in case to provide `inline` keyword for the compiler because some compiler with other options won't inline these and will cause a call overhead. What's worse, when this happened, this function is not in IRAM so the overhead is significant.

In my forked library I even use `__attribute__((always_inline)) inline` instead of regular `inline` because if you use menuconfig to build in "Release" mode, the compiler is in "optimization for Size `-Os` " hence sometimes compiler tries to override any inline keyword, leading to worse performance compared to Debug mode.

In my forked version of ESP8266_RTOS_SDK, with this little change, my air conditioner accept the IR signal with 100% rate. (originally ~95%) without this change.